### PR TITLE
Create Update for Week-3 2021

### DIFF
--- a/gnosis/Gov Weekly/Update Week-3 2021, 02-16-21.md
+++ b/gnosis/Gov Weekly/Update Week-3 2021, 02-16-21.md
@@ -1,0 +1,50 @@
+### Governance Update - Week-3 2021
+
+#### Live Votes
+| Name          | Category      | Link   |
+| ------------- |:-------------:| :-----:|
+| GIP-5: Remove Gnosis Impact from the GnosisDAO Governance Process | Meta | [Vote](https://deploy-preview-889--dgov-staging.netlify.app/gnosis/poll/QmfEpoQtvjWMeRwfeFvothLDkFqaXCZNHU9ZFb3S3cuLRU) |
+
+Gnosis Impact is currently an integral component of the Gnosis governance process.
+The current implementation of Gnosis Impact has known flaws and poses uncalled-for obstacles to pass proposals through the governance process.
+
+This proposal aims to exclude the obligatory utilization of Gnosis Impact as part of the GnosisDAO’s governance process phase 3 until a proposal passes amending its shortcomings.
+
+#### Discussions
+| Name          | Category      | Link   |
+| ------------- |:-------------:| :-----:|
+| GIP-4: Should GnosisDAO pay additional GNO rewards for GNO<>ETH LP on Sushiswap? | Treasury | [View](https://deploy-preview-889--dgov-staging.netlify.app/gnosis/forum/1013) |
+
+The objective of this proposal is to kick off a crossDAO collaboration attempting to increase number of stakeholders for both communities (Sushi and GnosisDAO). The proposal seeks a liquidity incentivisation campaign  with the following goals:
+- Creating stakeholders for both communities
+- Foment cross-DAO collaborations in the future
+- Increase GNO liquidity
+
+
+| Name          | Category      | Link   |
+| ------------- |:-------------:| :-----:|
+| GIP-6 Deploy Gnosis Auction | Meta | [View](https://deploy-preview-889--dgov-staging.netlify.app/gnosis/forum/1078) |
+
+This GIP intends to answer the question: Should GnosisDAO deploy GnosisAuction?
+
+GnosisAuction would build on the proven success with token sales that Gnosis Protocol (GP) v1 (Mesa) had. It will provide a sturdy mechanism that supports fair price finding in token sales. It will also aim to be modular enough to work in other scenarios where auctions are needed.
+
+
+| Name          | Category      | Link   |
+| ------------- |:-------------:| :-----:|
+| Gnosis Safe: SushiSwap Safe App Grant | Treasury | [View](https://forum.gnosis.io/t/gnosis-safe-sushiswap-safe-app-grant/1069) |
+
+Gnosis and Sushi are collaborating to offer a shared Safe Apps grant of up to $6,000, consisting of $3,000 in DAI plus a matching $3,000 in SUSHI.
+This grant is open to any individual or team that develops a Safe App for the following applications:
+- Sushi Liquidity Management App
+- Cream
+- yGift (Support for v2 included)
+- Bento (Upon release)
+
+
+| Name          | Category      | Link   |
+| ------------- |:-------------:| :-----:|
+| Gnosis Safe: ENS Safe App Grant | Treasury | [View](https://forum.gnosis.io/t/gnosis-safe-ens-safe-app-grant/1077/1) |
+
+Gnosis Safe and ENS are teaming up to offer another Safe Apps grant of up to $6,000, consisting of $3,000 in DAI plus a matching $3,000 in ETH.
+This grant is open to any individual or team that develops an ENS Safe App with specific conditions found [here](https://forum.gnosis.io/t/gnosis-safe-ens-safe-app-grant/1077/1)


### PR DESCRIPTION
Added file containing Gov Updates for Week 3 2021.
Includes 3GIPs + 2 Grant Announcements


Questions/Concerns:

1) Grants seems more like Announcements than governance Discussions or Votes to be had. Wondering if you prefer these are included under 'Discussions Category' or if I should have made a new category (i.e. Announcements or Core Team Announcements)

2) GIP 4 and 6 are not currently listed in Gnosis' Snapshot, they are in its forum. So, they cannot be voted on within boardroom but they Can be voted on within Gnosis' native forum. I included these GIPs under discussions but was unsure whether I should have included them in the 'Live Votes' category instead

3) Within each of the 5 updates, I listed the same category outlined by the authors of these proposals. However, these did not always seem like the best choice relative to the proposal. For example, GIP-4 seems to be more of a Marketing proposal (Token Airdrops) than a Treasury proposal. Yet, the author of the proposal lists its 'Type' as 'Funding' in the Gnosis Forum. Is it best to go with the category listed by the author or to use best judgement?
